### PR TITLE
Change to disable statsd

### DIFF
--- a/setup-production.adoc
+++ b/setup-production.adoc
@@ -429,6 +429,10 @@ PYTHONPATH=/home/taiga/.virtualenvs/taiga/lib/python3.5/site-packages
 Circus stats can generate a high cpu usage without any load you can set statsd
 in `/etc/circus/circusd.conf` to false if you don't need them.
 
+As of Ubuntu 16.04, there is no more /etc/circus/circusd.conf but /etc/circus/circusd.ini with endpoint
+configured for statsd. As statsd, is to false by default ( http://circus.readthedocs.io/en/latest/for-ops/configuration/ ), not comment the endpoint seems to make statsd  started.
+Line to be commented in /etc/circus/circusd.ini to stop statsd : `stats_endpoint = tcp://127.0.0.1:5557`
+
 Taiga stores logs on the user home, making them available and immediately accessible when
 you enter a machine. To make everything work, make sure you have the logs directory
 created.


### PR DESCRIPTION
Hello,

One update made to 7.1 notes.
- no more /etc/circus/circusd.conf but /etc/circus/circusd.ini
- statsd is defaulted to false, but started by enabling endpoint in /etc/circus/circusd.ini

Check today on a fresh upgraded install  : 
- Ubuntu serveur 16.04 - circus 0.12.1

Needs some confirmation.

Thanks,

Eric